### PR TITLE
Fix: checks on RESTful methods

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
@@ -188,7 +188,7 @@ public class CodegenOperation {
      * @return true if act as Restful index method, false otherwise
      */
     public boolean isRestfulIndex() {
-        return "GET".equalsIgnoreCase(httpMethod) && "".equals(pathWithoutBaseName());
+        return "GET".equalsIgnoreCase(httpMethod) && !isMemberPath();
     }
 
     /**
@@ -206,7 +206,7 @@ public class CodegenOperation {
      * @return true if act as Restful create method, false otherwise
      */
     public boolean isRestfulCreate() {
-        return "POST".equalsIgnoreCase(httpMethod) && "".equals(pathWithoutBaseName());
+        return "POST".equalsIgnoreCase(httpMethod) && !isMemberPath();
     }
 
     /**
@@ -255,14 +255,14 @@ public class CodegenOperation {
     }
 
     /**
-     * Check if the path match format /xxx/:id
+     * Check if the path ends with /xxx/:id
      *
      * @return true if path act as member
      */
     private boolean isMemberPath() {
-        if (pathParams.size() != 1) return false;
-        String id = pathParams.get(0).baseName;
-        return ("/{" + id + "}").equals(pathWithoutBaseName());
+        if (pathParams.size() < 1) return false;
+        String id = pathParams.get(pathParams.size() - 1).baseName;
+        return path.endsWith("/{" + id + "}");
     }
 
     @Override


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Right now, the `open-api-generator` recognizes the RESTful operations from **our swagger file** only for resources like:
- `/datacenters/{datacenterId}`

This PR updates the code to correctly recognize the RESTful operations from **our swagger file** for all resources, including for example:
- `/datacenters/{datacenterId}`
- `/datacenters/{datacenterId}/volumes/{volumeId}` 

Also, we needed a way to diferentiate between FindById operation which is `isRestfulShow` and Get operation which is `isRestfulIndex`. This PR updates `isMemberPath` function specifically for that. And to be able to get correct info request about resources that are on top of other resources. (e.g. volumes, servers)

The flags set will be used in the templates for the SDKs. 

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.3.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
