### PR TITLE
feat: implement support for acronyms

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/StringUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/StringUtils.java
@@ -7,12 +7,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.openapitools.codegen.config.GlobalSettings;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -81,6 +76,8 @@ public class StringUtils {
             result = pkgSeparatorPattern.matcher(wordToUnderscore).replaceAll("/");
             // Replace $ with two underscores for inner classes.
             result = dollarPattern.matcher(result).replaceAll("__");
+            // Normalize uppercase/lowercase letters in acronyms
+            result = escapeWordTokens(result);
             // Replace capital letter with _ plus lowercase letter.
             result = capitalLetterPattern.matcher(result).replaceAll(replacementPattern);
             result = lowercasePattern.matcher(result).replaceAll(replacementPattern);
@@ -90,6 +87,18 @@ public class StringUtils {
             result = result.toLowerCase(Locale.ROOT);
             return result;
         });
+    }
+
+    private static String escapeWordTokens(String result) {
+        List<String> escapedWordTokens = new ArrayList<>();
+        String escapedWordTokensProperty = GlobalSettings.getProperty("escapedWordTokens");
+        if(escapedWordTokensProperty != null) {
+            escapedWordTokens = Arrays.asList(escapedWordTokensProperty.split(","));
+        }
+        for(String token : escapedWordTokens) {
+            result = result.replaceAll(token, token.charAt(0) + token.substring(1).toLowerCase(Locale.ROOT));
+        }
+        return result;
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/StringUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/StringUtils.java
@@ -89,6 +89,12 @@ public class StringUtils {
         });
     }
 
+    /**
+     * Escapes the Word Tokens set on escapedWordTokens Global Property.
+     * E.g. deleteABC -> deleteAbc; the result can be then transformed into snake case as delete_abc.
+     * @param result The name of the property
+     * @return The processed name of the property, with the tokens escaped
+     */
     private static String escapeWordTokens(String result) {
         List<String> escapedWordTokens = new ArrayList<>();
         String escapedWordTokensProperty = GlobalSettings.getProperty("escapedWordTokens");


### PR DESCRIPTION
## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This PR adds support for acronyms. The acronyms will be provided as a list in the global properties section.

The generate command will be used in the following way:

java -jar openapi-generator-cli.jar generate **--global-property escapedWordTokens=SQL**

For snake case specific languages, a `manageSQL` property will be generated as `manage_sql`

## Checklist

<!-- Please check the completed items below -->

<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. feat/fix/doc/test/refactor/etc)
- [ ] Tests added or updated
- [ ] Documentation updated

