### PR TITLE
fix: remove inner suffix for inline models

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/InlineModelResolver.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/InlineModelResolver.java
@@ -65,7 +65,9 @@ public class InlineModelResolver {
     final Logger LOGGER = LoggerFactory.getLogger(InlineModelResolver.class);
 
     public InlineModelResolver() {
-        this.inlineSchemaNameDefaults.put("arrayItemSuffix", "_inner");
+        // Ionos Note (alex): This was used to append Inner to nested array properties.
+        // Would have been a breaking change for SDKs
+        this.inlineSchemaNameDefaults.put("arrayItemSuffix", "");
         this.inlineSchemaNameDefaults.put("mapItemSuffix", "_value");
     }
 


### PR DESCRIPTION
hack to remove all "Inner" words from schemas. I'm still investigating the callstack to see where "Inner" is appended for a more robust fix 