### PR TITLE
fix: generate using primitives for python

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -106,9 +106,11 @@ public class PythonClientCodegen extends AbstractPythonCodegen implements Codege
         importMapping.clear();
 
         // override type mapping in abstract python codegen
-        typeMapping.put("array", "List");
-        typeMapping.put("set", "List");
-        typeMapping.put("map", "Dict");
+        //ionos - we don't want to use typing.List instead of list
+        // it's a breaking change that seems without a real benefit
+        typeMapping.put("array", "list");
+        typeMapping.put("set", "list");
+        typeMapping.put("map", "dict");
         typeMapping.put("decimal", "decimal.Decimal");
         typeMapping.put("file", "bytearray");
         typeMapping.put("binary", "bytearray");
@@ -723,7 +725,8 @@ public class PythonClientCodegen extends AbstractPythonCodegen implements Codege
                 constraints += ", unique_items=True";
             }
             pydanticImports.add("conlist");
-            typingImports.add("List"); // for return type
+            //ionos - use primitives, not typing.List
+            typingImports.add("list"); // for return type
             return String.format(Locale.ROOT, "conlist(%s%s)",
                     getPydanticType(cp.items, typingImports, pydanticImports, datetimeImports, modelImports, exampleImports, classname),
                     constraints);


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Python should use `list` primitve instead of `typing.List`.

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
