### PR TITLE
fix: remove context docs from main Readme

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/README.mustache
+++ b/modules/openapi-generator/src/main/resources/go/README.mustache
@@ -65,23 +65,6 @@ ctx := context.WithValue(context.Background(), {{packageName}}.ContextServerVari
 
 Note, enum values are always validated and all unused variables are silently ignored.
 
-### URLs Configuration per Operation
-
-Each operation can use different server URL defined using `OperationServers` map in the `Configuration`.
-An operation is uniquely identified by `"{classname}Service.{nickname}"` string.
-Similar rules for overriding default operation server index and variables applies by using `sw.ContextOperationServerIndices` and `sw.ContextOperationServerVariables` context maps.
-
-```golang
-ctx := context.WithValue(context.Background(), {{packageName}}.ContextOperationServerIndices, map[string]int{
-	"{classname}Service.{nickname}": 2,
-})
-ctx = context.WithValue(context.Background(), {{packageName}}.ContextOperationServerVariables, map[string]map[string]string{
-	"{classname}Service.{nickname}": {
-		"port": "8443",
-	},
-})
-```
-
 ## Documentation for API Endpoints
 
 All URIs are relative to *{{basePath}}*


### PR DESCRIPTION
Docs were not generated correctly for this part. It should be moved to api_docs.mustache generation