### PR TITLE
feat: Modify the code so the generation logic is the same as for the …

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/InlineModelResolver.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/InlineModelResolver.java
@@ -64,7 +64,7 @@ public class InlineModelResolver {
     final Logger LOGGER = LoggerFactory.getLogger(InlineModelResolver.class);
 
     public InlineModelResolver() {
-        this.inlineSchemaOptions.put("ARRAY_ITEM_SUFFIX", "_inner");
+        this.inlineSchemaOptions.put("ARRAY_ITEM_SUFFIX", "");
         this.inlineSchemaOptions.put("MAP_ITEM_SUFFIX", "_value");
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1415,17 +1415,20 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     }
 
     private String getDefaultCollectionType(Schema schema, String defaultValues) {
-        String arrayFormat = "new %s<>(Arrays.asList(%s))";
+        String arrayFormat = "new %s<%s>(Arrays.asList(%s))";
+        Schema<?> items = getSchemaItems(schema);
+        String typeDeclaration = getTypeDeclaration(ModelUtils.unaliasSchema(this.openAPI, items));
+
         if (defaultValues == null || defaultValues.isEmpty()) {
             defaultValues = "";
-            arrayFormat = "new %s<>()";
+            arrayFormat = "new %s<%s>()";
         }
 
         if (ModelUtils.isSet(schema)) {
             return String.format(Locale.ROOT, arrayFormat,
-                    instantiationTypes().getOrDefault("set", "LinkedHashSet"), defaultValues);
+                    instantiationTypes().getOrDefault("set", "LinkedHashSet"), typeDeclaration, defaultValues);
         }
-        return String.format(Locale.ROOT, arrayFormat, instantiationTypes().getOrDefault("array", "ArrayList"), defaultValues);
+        return String.format(Locale.ROOT, arrayFormat, instantiationTypes().getOrDefault("array", "ArrayList"), typeDeclaration, defaultValues);
     }
 
     @Override


### PR DESCRIPTION
…old code so there are no differences in SDK gen

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
