### PR TITLE
fix: remove setting default values from the swagger in the sdk, make all fields optional

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -2130,12 +2130,10 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
         }
 
         private String finalizeType(CodegenProperty cp, PythonType pt) {
-            if (!cp.required || cp.isNullable) {
-                moduleImports.add("typing", "Optional");
-                PythonType opt = new PythonType("Optional");
-                opt.addTypeParam(pt);
-                pt = opt;
-            }
+            moduleImports.add("typing", "Optional");
+            PythonType opt = new PythonType("Optional");
+            opt.addTypeParam(pt);
+            pt = opt;
 
             if (!StringUtils.isEmpty(cp.description)) { // has description
                 pt.annotate("description", cp.description);
@@ -2152,19 +2150,19 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
             }*/
 
             //String defaultValue = null;
-            if (!cp.required) { //optional
-                if (cp.defaultValue == null) {
-                    pt.setDefaultValue("None");
-                } else {
-                    if (cp.isArray || cp.isMap) {
-                        // TODO handle default value for array/map
-                        pt.setDefaultValue("None");
-                    } else {
-                        //defaultValue = ;
-                        pt.setDefaultValue(cp.defaultValue);
-                    }
-                }
-            }
+            //optional
+            pt.setDefaultValue("None");
+            // if (cp.defaultValue == null) {
+            //     pt.setDefaultValue("None");
+            // } else {
+            //     if (cp.isArray || cp.isMap) {
+            //         // TODO handle default value for array/map
+            //         pt.setDefaultValue("None");
+            //     } else {
+            //         //defaultValue = ;
+            //         pt.setDefaultValue(cp.defaultValue);
+            //     }
+            // }
 
             String typeConstraint = pt.asTypeConstraint(moduleImports);
             String typeValue = pt.asTypeValue(moduleImports);
@@ -2211,12 +2209,10 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
         }
 
         private String finalizeType(CodegenParameter cp, PythonType pt) {
-            if (!cp.required || cp.isNullable) {
-                moduleImports.add("typing", "Optional");
-                PythonType opt = new PythonType("Optional");
-                opt.addTypeParam(pt);
-                pt = opt;
-            }
+            moduleImports.add("typing", "Optional");
+            PythonType opt = new PythonType("Optional");
+            opt.addTypeParam(pt);
+            pt = opt;
 
             if (!StringUtils.isEmpty(cp.description)) { // has description
                 pt.annotate("description", cp.description);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -2130,6 +2130,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
         }
 
         private String finalizeType(CodegenProperty cp, PythonType pt) {
+            // ionos - remove if, make all optional
             moduleImports.add("typing", "Optional");
             PythonType opt = new PythonType("Optional");
             opt.addTypeParam(pt);
@@ -2151,6 +2152,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
 
             //String defaultValue = null;
             //optional
+            // ionos - remove all default values, use None
             pt.setDefaultValue("None");
             // if (cp.defaultValue == null) {
             //     pt.setDefaultValue("None");
@@ -2209,6 +2211,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
         }
 
         private String finalizeType(CodegenParameter cp, PythonType pt) {
+            // ionos - remove if, make all optional
             moduleImports.add("typing", "Optional");
             PythonType opt = new PythonType("Optional");
             opt.addTypeParam(pt);


### PR DESCRIPTION
…all fields optional

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
