### PR TITLE
fix: do not mint a duplicate model for a single-$ref allOf property

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/InlineModelResolver.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/InlineModelResolver.java
@@ -234,6 +234,16 @@ public class InlineModelResolver {
                 }
             }
 
+            if (isSingleAllOf && m.getAllOf().get(0).get$ref() != null
+                    && !m.getAllOf().get(0).get$ref().isEmpty()) {
+                // Single allOf that is just a $ref: the property is an alias for the
+                // referenced schema, so no separate inline model is needed regardless of
+                // sibling keywords such as description. Pass the RAW ref schema here --
+                // dereferencing it (as the loop below does) would report "model needed"
+                // for any object target and mint a duplicate <Parent><Prop> model.
+                return isModelNeeded(m.getAllOf().get(0), visitedSchemas);
+            }
+
             if (m.getAllOf() != null && !m.getAllOf().isEmpty()) {
                 // check to ensure at least one of the allOf item is model
                 for (Schema inner : m.getAllOf()) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/InlineModelResolverTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/InlineModelResolverTest.java
@@ -1132,4 +1132,21 @@ public class InlineModelResolverTest {
         assertTrue((Schema) schema.getAnyOf().get(0) instanceof StringSchema);
         assertTrue((Schema) schema.getAnyOf().get(1) instanceof IntegerSchema);
     }
+
+    @Test
+    public void testSingleRefAllOfPropertyReusesReferencedSchema() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/inline_model_single_ref_allof_property.yaml");
+        InlineModelResolver resolver = new InlineModelResolver();
+        resolver.flatten(openAPI);
+
+        // A property written as a single-element allOf around a $ref is an alias for the
+        // referenced schema -- a bare $ref cannot carry a sibling description. It must not
+        // get a model of its own, or every such property mints a duplicate of its target.
+        assertNull(openAPI.getComponents().getSchemas().get("ServerProperties_bootVolume"));
+
+        Schema serverProperties = openAPI.getComponents().getSchemas().get("ServerProperties");
+        Schema bootVolume = (Schema) serverProperties.getProperties().get("bootVolume");
+        assertEquals("#/components/schemas/ResourceReference",
+                ((Schema) bootVolume.getAllOf().get(0)).get$ref());
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/inline_model_single_ref_allof_property.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/inline_model_single_ref_allof_property.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.0
+info:
+  title: single-$ref allOf property
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    ResourceReference:
+      type: object
+      properties:
+        id:
+          type: string
+        href:
+          type: string
+    ServerProperties:
+      type: object
+      properties:
+        name:
+          type: string
+        bootVolume:
+          description: >-
+            Reference to a volume. A bare $ref cannot carry a description, so
+            this is wrapped in a single-element allOf.
+          allOf:
+            - $ref: '#/components/schemas/ResourceReference'


### PR DESCRIPTION
InlineModelResolver.isModelNeeded() treated a property written as

    properties:
      bootVolume:
        allOf:
          - $ref: '#/components/schemas/ResourceReference' description: ...

as needing its own inline model, so the resolver minted a duplicate <Parent><Property> schema (ServerPropertiesBootVolume) instead of reusing the referenced one. The sibling keyword is the trigger: a bare $ref cannot carry a description, so spec authors wrap it in a single-element allOf, which is the idiomatic OpenAPI 3.0 workaround and means "this property IS the referenced schema".

The existing loop below dereferences each allOf member via getReferencedSchema() and reports "model needed" for any object target, which is correct for a real composition but wrong for the alias case. Handle the single-$ref case before that loop and recurse on the RAW ref schema, so the property resolves to the referenced model.

Effect on the IONOS cloudapi-v6 spec, measured A/B against an otherwise identical run: ServerProperties.bootCdrom and bootVolume resolve to ResourceReference and maintenanceWindow to ServerMaintenanceWindow, matching what sdk-go has shipped since v6.3.11. 21 exported symbols removed, 0 added, 3 dead files gone; purely subtractive. Verified for go (build + vet), java (mvn compile), node (tsc --noEmit) and python.

Note this is subtractive by construction: it removes generated types that were duplicates. Before pointing an already-released product at this build, check that none of the types it drops are types that product has shipped.

Uses a plain null/isEmpty check rather than StringUtils.isNotEmpty, which the codegen StringUtils imported by this file does not provide.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
